### PR TITLE
Make Punch Streams Incremental

### DIFF
--- a/tap_dayforce/schemas/employee_punches.json
+++ b/tap_dayforce/schemas/employee_punches.json
@@ -124,6 +124,10 @@
           }
         }
       }
+    },
+    "SyncTimestampUtc": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_dayforce/schemas/employee_raw_punches.json
+++ b/tap_dayforce/schemas/employee_raw_punches.json
@@ -133,6 +133,10 @@
     },
     "Accuracy": {
       "type": ["null", "integer"]
+    },
+    "SyncTimestampUtc": {
+      "type": ["null", "string"],
+      "format": "date-time"
     }
   }
 }

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 import time
-from datetime import timedelta, datetime
+from datetime import timedelta
 from typing import Dict, Generator
 
 import requests

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 import time
-from datetime import timedelta
+from datetime import timedelta, datetime
 from typing import Dict, Generator
 
 import requests
@@ -10,6 +10,8 @@ import singer
 from .version import __version__
 
 LOGGER = singer.get_logger()
+
+BOOKMARK_DATETIME_STR_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 WHITELISTED_COLLECTIONS = {
     'CompensationSummary',
@@ -181,7 +183,7 @@ class EmployeesStream(DayforceStream):
 
     def sync(self):
 
-        new_bookmark = singer.utils.strftime(singer.utils.now(), '%Y-%m-%dT%H:%M:%SZ')
+        new_bookmark = singer.utils.strftime(singer.utils.now(), BOOKMARK_DATETIME_STR_FMT)
         current_bookmark = singer.bookmarks.get_bookmark(state=self.state,
                                                          tap_stream_id=self.tap_stream_id,
                                                          key=self.replication_key)
@@ -221,10 +223,10 @@ class EmployeesStream(DayforceStream):
 class EmployeePunchesStream(DayforceStream):
     tap_stream_id = 'employee_punches'
     stream = 'employee_punches'
-    replication_key = 'LastModifiedTimestampUtc'
-    valid_replication_keys = ['LastModifiedTimestampUtc']
+    replication_key = 'SyncTimestampUtc'
+    valid_replication_keys = ['SyncTimestampUtc']
     key_properties = 'PunchXRefCode'
-    replication_method = 'FULL_TABLE'
+    replication_method = 'INCREMENTAL'
     required_params = ['filterTransactionStartTimeUTC']
     valid_params = [
         'filterTransactionStartTimeUTC',
@@ -244,13 +246,28 @@ class EmployeePunchesStream(DayforceStream):
     def __init__(self, config: Dict, state: Dict):
         super().__init__(config, state)
 
-        if 'filterTransactionEndTimeUTC' not in self.params.keys():
-            filter_transaction_end_time = {
-                "filterTransactionEndTimeUTC": singer.utils.strftime(singer.utils.now(), '%Y-%m-%dT%H:%M:%SZ')
-            }
-            self.params.update(filter_transaction_end_time)
-
     def sync(self):
+
+        new_bookmark = singer.utils.strftime(singer.utils.now(), BOOKMARK_DATETIME_STR_FMT)
+
+        self.params.update({
+            "filterTransactionEndTimeUTC": new_bookmark
+        })
+
+        current_bookmark = singer.bookmarks.get_bookmark(state=self.state,
+                                                         tap_stream_id=self.tap_stream_id,
+                                                         key=self.replication_key)
+
+        if current_bookmark is not None:
+            self.params.update({
+                "filterTransactionStartTimeUTC": current_bookmark
+            })
+
+        self.state = singer.bookmarks.write_bookmark(state=self.state,
+                                                     tap_stream_id=self.tap_stream_id,
+                                                     key=self.replication_key,
+                                                     val=new_bookmark)
+
         start = singer.utils.strptime_to_utc(self.params.get('filterTransactionStartTimeUTC'))
         end = singer.utils.strptime_to_utc(self.params.get('filterTransactionEndTimeUTC'))
         step = timedelta(days=7)
@@ -264,6 +281,7 @@ class EmployeePunchesStream(DayforceStream):
                     }
                     self.params.update(range)
                     for punch in self._get_records(resource='EmployeePunches', params=self.params):
+                        punch["SyncTimestampUtc"] = new_bookmark
                         with singer.Transformer() as transformer:
                             transformed_record = transformer.transform(data=punch, schema=self.schema)
                             singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
@@ -274,10 +292,10 @@ class EmployeePunchesStream(DayforceStream):
 class EmployeeRawPunchesStream(DayforceStream):
     tap_stream_id = 'employee_raw_punches'
     stream = 'employee_raw_punches'
-    replication_key = 'LastModifiedTimestampUtc'
-    valid_replication_keys = ['LastModifiedTimestampUtc']
+    replication_key = 'SyncTimestampUtc'
+    valid_replication_keys = ['SyncTimestampUtc']
     key_properties = 'RawPunchXRefCode'
-    replication_method = 'FULL_TABLE'
+    replication_method = 'INCREMENTAL'
     required_params = ['filterTransactionStartTimeUTC']
     valid_params = [
         'filterTransactionStartTimeUTC',
@@ -292,13 +310,28 @@ class EmployeeRawPunchesStream(DayforceStream):
     def __init__(self, config: Dict, state: Dict):
         super().__init__(config, state)
 
-        if 'filterTransactionEndTimeUTC' not in self.params.keys():
-            filter_transaction_end_time = {
-                "filterTransactionEndTimeUTC": singer.utils.strftime(singer.utils.now(), '%Y-%m-%dT%H:%M:%SZ')
-            }
-            self.params.update(filter_transaction_end_time)
-
     def sync(self):
+
+        new_bookmark = singer.utils.strftime(singer.utils.now(), BOOKMARK_DATETIME_STR_FMT)
+
+        self.params.update({
+            "filterTransactionEndTimeUTC": new_bookmark
+        })
+
+        current_bookmark = singer.bookmarks.get_bookmark(state=self.state,
+                                                         tap_stream_id=self.tap_stream_id,
+                                                         key=self.replication_key)
+
+        if current_bookmark is not None:
+            self.params.update({
+                "filterTransactionStartTimeUTC": current_bookmark
+            })
+
+        self.state = singer.bookmarks.write_bookmark(state=self.state,
+                                                     tap_stream_id=self.tap_stream_id,
+                                                     key=self.replication_key,
+                                                     val=new_bookmark)
+
         start = singer.utils.strptime_to_utc(self.params.get('filterTransactionStartTimeUTC'))
         end = singer.utils.strptime_to_utc(self.params.get('filterTransactionEndTimeUTC'))
         step = timedelta(days=7)
@@ -312,6 +345,7 @@ class EmployeeRawPunchesStream(DayforceStream):
                     }
                     self.params.update(range)
                     for punch in self._get_records(resource='EmployeeRawPunches', params=self.params):
+                        punch["SyncTimestampUtc"] = new_bookmark
                         with singer.Transformer() as transformer:
                             transformed_record = transformer.transform(data=punch, schema=self.schema)
                             singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)


### PR DESCRIPTION
This PR updates the two Punch streams (`EmployeePunches` and `EmployeeRawPunches`) to sync incrementally instead of full re-syncs each run. This is now possible given new information received from Dayforce about the mapping of certain API parameters to modification fields.