### PR TITLE
Add support for replicating Dayforce reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script: tox
 branches:
   only:
     - master
+    - dev/payrate-blacklist

--- a/tap_dayforce/__init__.py
+++ b/tap_dayforce/__init__.py
@@ -5,8 +5,7 @@ import rollbar
 import singer
 from rollbar.logger import RollbarHandler
 
-from .streams import AVAILABLE_STREAMS
-from .streams import ReportStream
+from .streams import AVAILABLE_STREAMS, ReportStream
 
 ROLLBAR_ACCESS_TOKEN = os.environ["ROLLBAR_ACCESS_TOKEN"]
 ROLLBAR_ENVIRONMENT = os.environ["ROLLBAR_ENVIRONMENT"]

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 import time
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from typing import Dict, Generator
 
 import requests
@@ -388,12 +388,12 @@ class ReportStream(DayforceStream):
         resp = self._get(resource=f"ReportMetadata/{report_xrefcode}")
         column_metadata = resp.get("Data")[0].get("ColumnMetadata")
         schema = {
-          "type": ["null", "object"],
-          "additionalProperties": False,
-          "properties": {}
+            "type": ["null", "object"],
+            "additionalProperties": False,
+            "properties": {}
         }
         for column in column_metadata:
-            field = column.get("CodeName").replace(".","_")
+            field = column.get("CodeName").replace(".", "_")
             if column.get("DataType") not in self.DATA_TYPE_MAPPING.keys():
                 raise TypeError(f"Column {column.get('DisplayName')} has data type {column.get('DataType')} which is not implemented.")
             else:
@@ -419,7 +419,6 @@ class ReportStream(DayforceStream):
                         counter.increment()
 
             singer.write_version(stream_name=self.stream, version=singer_version)
-
 
 
 AVAILABLE_STREAMS = {EmployeesStream, EmployeePunchesStream, EmployeeRawPunchesStream, ReportStream}

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 import time
-from datetime import timedelta
+from datetime import timedelta, datetime
 from typing import Dict, Generator
 
 import requests
@@ -353,4 +353,73 @@ class EmployeeRawPunchesStream(DayforceStream):
                     start += step
 
 
-AVAILABLE_STREAMS = {EmployeesStream, EmployeePunchesStream, EmployeeRawPunchesStream}
+class ReportStream(DayforceStream):
+    DATA_TYPE_MAPPING = {
+        "String": {"type": ["null", "string"]},
+        "Integer": {"type": ["null", "integer"]},
+        "Decimal": {"type": ["null", "number"]},
+        "DateTime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "Time": {
+            "type": ["null", "string"]
+        },
+        "Date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        }
+    }
+    key_properties = []
+    valid_replication_keys = []
+    replication_method = 'FULL_TABLE'
+    required_params = []
+
+    def __init__(self, config: Dict, state: Dict, xrefcode: str):
+        self.tap_stream_id = f"report_{xrefcode}"
+        self.stream = f"report_{xrefcode}"
+        self.xrefcode = xrefcode
+        self.key_properties = []
+        self.valid_replication_keys = []
+        super().__init__(config, state)
+
+    def _generate_schema(self, report_xrefcode: str) -> Dict:
+        '''Dynamically generates a schema for a Report by inspecting the ReportMetadata endpoint.'''
+        resp = self._get(resource=f"ReportMetadata/{report_xrefcode}")
+        column_metadata = resp.get("Data")[0].get("ColumnMetadata")
+        schema = {
+          "type": ["null", "object"],
+          "additionalProperties": False,
+          "properties": {}
+        }
+        for column in column_metadata:
+            field = column.get("CodeName").replace(".","_")
+            if column.get("DataType") not in self.DATA_TYPE_MAPPING.keys():
+                raise TypeError(f"Column {column.get('DisplayName')} has data type {column.get('DataType')} which is not implemented.")
+            else:
+                schema.get("properties").update({field: self.DATA_TYPE_MAPPING.get(column.get("DataType"))})
+
+        return schema
+
+    def _load_schema(self) -> Dict:
+        return self._generate_schema(report_xrefcode=self.xrefcode)
+
+    def sync(self):
+        singer_version = int(datetime.utcnow().timestamp())
+        with singer.metrics.job_timer(job_type=f"sync_{self.tap_stream_id}"):
+            with singer.metrics.record_counter(endpoint=self.tap_stream_id) as counter:
+                resp = self._get(resource=f"Reports/{self.xrefcode}", params=self.params)
+                for row in resp.get("Data").get("Rows"):
+                    with singer.Transformer() as transformer:
+                        transformed_record = transformer.transform(data=row, schema=self.schema)
+                        singer.write_message(singer.RecordMessage(stream=self.stream,
+                                                                  record=transformed_record,
+                                                                  version=singer_version,
+                                                                  time_extracted=singer.utils.now()))
+                        counter.increment()
+
+            singer.write_version(stream_name=self.stream, version=singer_version)
+
+
+
+AVAILABLE_STREAMS = {EmployeesStream, EmployeePunchesStream, EmployeeRawPunchesStream, ReportStream}


### PR DESCRIPTION
This PR adds the ability to replicate Dayforce reports into our data warehouse. It includes a few notable features:

1. **All configuration for choosing which reports to replicate is done via the configuration file.** For example, a Dayforce configuration file may look like the following:

```json
{
  "username": "<user>",
  "password": "<password>",
  "client_name": "<client>",
  "email": "<email>",
  "streams": {
    "employees": {
      "expand": "WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers"
    },
    "employee_punches": {
      "filterTransactionStartTimeUTC": "2019-06-01T00:00:00Z"
    },
    "employee_raw_punches": {
      "filterTransactionStartTimeUTC": "2019-06-01T00:00:00Z"
    },
    "reports": {
      "test1": {},
      "test2": {}
    }
  }
}
```

This will instruct the tap to replicate the reports with XRefCode's `test1` and `test2`. They will replicate into tables that are prefixed with `report_` (e.g. `report_test1`). Any additional parameters can be supplied in the nested values under each Report XRefCode.

2. **Schemas for Report entities are generated dynamically on each run using the `/ReportMetadata` Dayforce API endpoint**. The singer `ACTIVE_VERSION` strategy is leveraged in order to ensure the removal of old data and replace the data with new data. This will ensure all data and schema changes are error-prone. However, this also means we will need to be vigilant with testing any downstream dbt models that end up depending on these tables.