### PR TITLE
Check and skip empty records

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -1,3 +1,3 @@
 remote: goodeggs/policy-bot
 path: policies/default.yml
-ref: dev/payrate-blacklist
+ref: master

--- a/.policy.yml
+++ b/.policy.yml
@@ -1,3 +1,3 @@
 remote: goodeggs/policy-bot
 path: policies/default.yml
-ref: master
+ref: dev/payrate-blacklist

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 import os
 import time
 from datetime import datetime, timedelta

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,10 +1,12 @@
 import inspect
+import json
 import os
 import time
 from datetime import datetime, timedelta
 from typing import Dict, Generator
 
 import requests
+import rollbar
 import singer
 
 from .version import __version__
@@ -201,22 +203,28 @@ class EmployeesStream(DayforceStream):
             with singer.metrics.record_counter(endpoint=self.tap_stream_id) as counter:
                 for page in self._get_records(resource='Employees', params=self.params):
                     for employee in page.get("Data"):
-                        resp = self._get(resource=f"Employees/{employee.get('XRefCode')}", params=self.params)
-                        data = resp.get('Data')
-                        # Custom blacklisting for sensitive pay information.
-                        for collection in WHITELISTED_COLLECTIONS:
-                            for i, item in enumerate(data.get(collection).get("Items")):
-                                if item.get("PayPolicy") is None:
-                                    for field in WHITELISTED_FIELDS:
-                                        data[collection]["Items"][i].pop(field, None)
-                                elif item.get("PayPolicy").get("XRefCode") not in WHITELISTED_PAY_POLICY_CODES:
-                                    for field in WHITELISTED_FIELDS:
-                                        data[collection]["Items"][i].pop(field, None)
-                        data['SyncTimestampUtc'] = new_bookmark
-                        with singer.Transformer() as transformer:
-                            transformed_record = transformer.transform(data=data, schema=self.schema)
-                            singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
-                            counter.increment()
+                        if not employee:
+                            msg = f"Dayforce returned an empty {self.tap_stream_id} record. Skipping it.."
+                            LOGGER.warning(msg)
+                            rollbar.report_message(msg, 'warning')
+                            continue
+                        else:
+                            resp = self._get(resource=f"Employees/{employee.get('XRefCode')}", params=self.params)
+                            data = resp.get('Data')
+                            # Custom blacklisting for sensitive pay information.
+                            for collection in WHITELISTED_COLLECTIONS:
+                                for i, item in enumerate(data.get(collection).get("Items")):
+                                    if item.get("PayPolicy") is None:
+                                        for field in WHITELISTED_FIELDS:
+                                            data[collection]["Items"][i].pop(field, None)
+                                    elif item.get("PayPolicy").get("XRefCode") not in WHITELISTED_PAY_POLICY_CODES:
+                                        for field in WHITELISTED_FIELDS:
+                                            data[collection]["Items"][i].pop(field, None)
+                            data['SyncTimestampUtc'] = new_bookmark
+                            with singer.Transformer() as transformer:
+                                transformed_record = transformer.transform(data=data, schema=self.schema)
+                                singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
+                                counter.increment()
 
 
 class EmployeePunchesStream(DayforceStream):
@@ -281,11 +289,17 @@ class EmployeePunchesStream(DayforceStream):
                     self.params.update(range)
                     for page in self._get_records(resource='EmployeePunches', params=self.params):
                         for punch in page.get("Data"):
-                            punch["SyncTimestampUtc"] = new_bookmark
-                            with singer.Transformer() as transformer:
-                                transformed_record = transformer.transform(data=punch, schema=self.schema)
-                                singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
-                                counter.increment()
+                            if not punch:
+                                msg = f"Dayforce returned an empty {self.tap_stream_id} record. Skipping it.."
+                                LOGGER.warning(msg)
+                                rollbar.report_message(msg, 'warning')
+                                continue
+                            else:
+                                punch["SyncTimestampUtc"] = new_bookmark
+                                with singer.Transformer() as transformer:
+                                    transformed_record = transformer.transform(data=punch, schema=self.schema)
+                                    singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
+                                    counter.increment()
                     start += step
 
 
@@ -346,11 +360,17 @@ class EmployeeRawPunchesStream(DayforceStream):
                     self.params.update(range)
                     for page in self._get_records(resource='EmployeeRawPunches', params=self.params):
                         for punch in page.get("Data"):
-                            punch["SyncTimestampUtc"] = new_bookmark
-                            with singer.Transformer() as transformer:
-                                transformed_record = transformer.transform(data=punch, schema=self.schema)
-                                singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
-                                counter.increment()
+                            if not punch:
+                                msg = f"Dayforce returned an empty {self.tap_stream_id} record. Skipping it.."
+                                LOGGER.warning(msg)
+                                rollbar.report_message(msg, 'warning')
+                                continue
+                            else:
+                                punch["SyncTimestampUtc"] = new_bookmark
+                                with singer.Transformer() as transformer:
+                                    transformed_record = transformer.transform(data=punch, schema=self.schema)
+                                    singer.write_record(stream_name=self.stream, time_extracted=singer.utils.now(), record=transformed_record)
+                                    counter.increment()
                     start += step
 
 


### PR DESCRIPTION
This PR implements a method of checking to see if a record returned from Dayforce is empty. If it is, it skips ingesting the record and instead logs a warning to Rollbar.