### PR TITLE
fix job_xrefcode casing

### DIFF
--- a/tap_dayforce/schemas/pay_summary_report.json
+++ b/tap_dayforce/schemas/pay_summary_report.json
@@ -24,7 +24,7 @@
     "Job_ShortName": {
       "type": ["null", "string"]
     },
-    "Job_XRefCode": {
+    "Job_XrefCode": {
       "type": ["null", "string"]
     },
     "ActualIn": {


### PR DESCRIPTION
This PR fixes the casing in the `Job_XrefCode` field to match what is returned from the Dayforce API.