### PR TITLE
Employee Rate Limiting + Empty XRefCodes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'tap_dayforce': ['schemas/*.json']
     },
     install_requires=[
-        'dayforce-client==0.1.0a1',
+        'dayforce-client==0.1.0',
         'singer-python==5.9.0',
         'backoff==1.8.0',
         'rollbar==0.14.7'

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import time
 from datetime import timedelta
 from typing import ClassVar, Dict, Iterable, List, Optional, Union
 

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -78,13 +78,13 @@ class EmployeePunchesStream(DayforcePunchStream):
 
     @backoff.on_exception(backoff.expo,
                           requests.exceptions.HTTPError,
-                          max_time=120,
+                          max_time=240,
                           giveup=is_fatal_code,
                           logger=LOGGER)
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError,
                            requests.exceptions.Timeout),
-                          max_time=120,
+                          max_time=240,
                           logger=LOGGER)
     def _transform_records(self, start, end, counter):
         for _, record in self.client.get_employee_punches(filterTransactionStartTimeUTC=singer.utils.strftime(start), filterTransactionEndTimeUTC=singer.utils.strftime(end)).yield_records():
@@ -105,13 +105,13 @@ class EmployeeRawPunchesStream(DayforcePunchStream):
 
     @backoff.on_exception(backoff.expo,
                           requests.exceptions.HTTPError,
-                          max_time=120,
+                          max_time=240,
                           giveup=is_fatal_code,
                           logger=LOGGER)
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError,
                            requests.exceptions.Timeout),
-                          max_time=120,
+                          max_time=240,
                           logger=LOGGER)
     def _transform_records(self, start, end, counter):
         for _, record in self.client.get_employee_raw_punches(filterTransactionStartTimeUTC=singer.utils.strftime(start), filterTransactionEndTimeUTC=singer.utils.strftime(end)).yield_records():
@@ -142,13 +142,13 @@ class EmployeesStream(DayforceStream):
 
     @backoff.on_exception(backoff.expo,
                           requests.exceptions.HTTPError,
-                          max_time=120,
+                          max_time=240,
                           giveup=is_fatal_code,
                           logger=LOGGER)
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError,
                            requests.exceptions.Timeout),
-                          max_time=120,
+                          max_time=240,
                           logger=LOGGER)
     def _transform_records(self, start, end, counter):
         for _, record in self.client.get_employees(filterUpdatedStartDate=singer.utils.strftime(start), filterUpdatedEndDate=singer.utils.strftime(end)).yield_records():
@@ -186,13 +186,13 @@ class PaySummaryReportStream(DayforceStream):
 
     @backoff.on_exception(backoff.expo,
                           requests.exceptions.HTTPError,
-                          max_time=120,
+                          max_time=240,
                           giveup=is_fatal_code,
                           logger=LOGGER)
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError,
                            requests.exceptions.Timeout),
-                          max_time=120,
+                          max_time=240,
                           logger=LOGGER)
     def _transform_records(self, start, end, counter):
         report_params = {

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -178,7 +178,7 @@ class EmployeesStream(DayforceStream):
             if record:
                 self._rate_limit(times=times, limit=(100,60))
                 details = self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers").get("Data")
-                if details:
+                if details.get("XRefCode") is not None:
                     details["SyncTimestampUtc"] = self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)
                     details = self.whitelist_sensitive_info(data=details)
                     with singer.Transformer() as transformer:

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -156,9 +156,9 @@ class EmployeesStream(DayforceStream):
             if record:
                 try:
                     response = self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers")
-                except requests.exceptions.HTTPError:
-                    if response.resp.status_code == 429:
-                        sleep_time = response.resp.headers["Retry-After"]
+                except requests.exceptions.HTTPError as e:
+                    if e.response.status_code == 429:
+                        sleep_time = int(e.response.headers["Retry-After"]) + 1
                         LOGGER.info(f"Rate limit reached. Retrying in {sleep_time} seconds..")
                         time.sleep(sleep_time)
                         response = self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers")

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -212,7 +212,7 @@ class PaySummaryReportStream(DayforceStream):
             "003cd1ea-5f11-4fe8-ae9c-d7af1e3a95d6": singer.utils.strftime(start),
             "b03cd1ea-5f11-4fe8-ae9c-d7af1e3a95d6": singer.utils.strftime(end)
         }
-        for _, row in self.client.get_report(xrefcode=self.tap_stream_id, **report_params).yield_report_rows(limit=(500,3600)):
+        for _, row in self.client.get_report(xrefcode=self.tap_stream_id, **report_params).yield_report_rows(limit=(500, 3600)):
             if row:
                 row["HashKey"] = self._generate_md5_hash(row.values())
                 row["SyncTimestampUtc"] = self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)


### PR DESCRIPTION
This PR updates the existing tap to enforce rate limiting according to Dayforce's best practices on the `Employees` stream. It also places a rate limit (custom to us) on the `PaySummaryReport` stream. In addition, it updates the `EmployeesStream` code to guard against Employee records with empty `XRefCode` values.

**NOTE:** This PR is dependent upon `dayforce-client` v0.1.0 being published.