### PR TITLE
Add Schedules Data to Employees Stream

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8]
+max-line-length = 120
+max-complexity = 15
+ignore =
+  E722
+count = True
+statistics = True
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    .mypy_cache,
+    .pytest_cache,
+    build,
+    config,
+    dist,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,9 @@
 [flake8]
-max-line-length = 120
 max-complexity = 15
 ignore =
+  E501
   E722
+  W503
 count = True
 statistics = True
 exclude =

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 120
+recursive = true

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-isort:
-	isort --recursive
+.PHONY: clean fmt lint test dev_install sanity_check
 
-flake8:
-	flake8 . --ignore=E501,E722 --count --statistics
+clean:
+	@rm -rf .tox .mypy_cache .pytest_cache dist/ build/ *.egg-info */__pycache__/
+
+fmt:
+	black .
+	isort --apply
+
+lint:
+	flake8 . --count --statistics
+	mypy .
 
 dev_install:
 	pip3 install --upgrade pip

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+black==19.10b0
 flake8==3.7.9
 isort==4.3.21
 mypy==0.761

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,3 @@ exclude = '''
   )/
 )
 '''
-
-[tool.pytest]
-addopts = "-v"
-testpaths = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,25 @@
 line-length = 120
 target-version = ['py36', 'py37', 'py38']
 include = '.py$'
-exclude = '(.git,.tox,__pycache__,.mypy_cache,.pytest_cache,build,config,dist,*.pyc,*.egg-info,.cache,.eggs)'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.pytest_cache
+    | \.tox
+    | \.venv
+    | \*.egg-info
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+)
+'''
 
 [tool.pytest]
 addopts = "-v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 120
+target-version = ['py36', 'py37', 'py38']
+include = '.py$'
+exclude = '(.git,.tox,__pycache__,.mypy_cache,.pytest_cache,build,config,dist,*.pyc,*.egg-info,.cache,.eggs)'
+
+[tool.pytest]
+addopts = "-v"
+testpaths = "tests"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = "-v"
+testpaths = "tests"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     license="GPLv3",
     packages=find_packages(exclude=["tests"]),
     package_data={"tap_dayforce": ["schemas/*.json"]},
-    install_requires=["dayforce-client==0.1.0", "singer-python==5.9.0", "backoff==1.8.0", "rollbar==0.14.7"],
+    install_requires=["dayforce-client==0.2.0", "singer-python==5.9.0", "backoff==1.8.0", "rollbar==0.14.7"],
     python_requires=">=3.6",
     entry_points={"console_scripts": ["tap-dayforce = tap_dayforce:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -3,50 +3,41 @@ from setuptools import find_packages, setup
 
 def get_version():
     version = {}
-    with open('tap_dayforce/version.py') as fp:
+    with open("tap_dayforce/version.py") as fp:
         exec(fp.read(), version)
-    return version['__version__']
+    return version["__version__"]
 
 
-with open('README.md', 'r') as f:
+with open("README.md", "r") as f:
     readme = f.read()
 
 
 setup(
-    name='tap_dayforce',
-    author='David Wallace',
-    author_email='david.wallace@goodeggs.com',
+    name="tap_dayforce",
+    author="David Wallace",
+    author_email="david.wallace@goodeggs.com",
     version=get_version(),
-    url='https://github.com/goodeggs/tap-dayforce',
-    description='Singer.io tap for extracting data from Dayforce REST API v1',
+    url="https://github.com/goodeggs/tap-dayforce",
+    description="Singer.io tap for extracting data from Dayforce REST API v1",
     long_description=readme,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Natural Language :: English',
-        'Topic :: Software Development',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Natural Language :: English",
+        "Topic :: Software Development",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     keywords="singer tap python dayforce",
-    license='GPLv3',
-    packages=find_packages(exclude=['tests']),
-    package_data={
-        'tap_dayforce': ['schemas/*.json']
-    },
-    install_requires=[
-        'dayforce-client==0.1.0',
-        'singer-python==5.9.0',
-        'backoff==1.8.0',
-        'rollbar==0.14.7'
-    ],
-    python_requires='>=3.6',
-    entry_points={
-        'console_scripts': ['tap-dayforce = tap_dayforce:main']
-    }
+    license="GPLv3",
+    packages=find_packages(exclude=["tests"]),
+    package_data={"tap_dayforce": ["schemas/*.json"]},
+    install_requires=["dayforce-client==0.1.0", "singer-python==5.9.0", "backoff==1.8.0", "rollbar==0.14.7"],
+    python_requires=">=3.6",
+    entry_points={"console_scripts": ["tap-dayforce = tap_dayforce:main"]},
 )

--- a/tap_dayforce/__init__.py
+++ b/tap_dayforce/__init__.py
@@ -5,16 +5,10 @@ import sys
 import rollbar
 import singer
 
-from .streams import (EmployeePunchesStream, EmployeeRawPunchesStream,
-                      EmployeesStream, PaySummaryReportStream)
+from .streams import EmployeePunchesStream, EmployeeRawPunchesStream, EmployeesStream, PaySummaryReportStream
 from .utils import load_schema, parse_args
 
-AVAILABLE_STREAMS = {
-    EmployeePunchesStream,
-    EmployeeRawPunchesStream,
-    EmployeesStream,
-    PaySummaryReportStream
-}
+AVAILABLE_STREAMS = {EmployeePunchesStream, EmployeeRawPunchesStream, EmployeesStream, PaySummaryReportStream}
 
 LOGGER = singer.get_logger()
 
@@ -30,7 +24,7 @@ else:
 
 
 def discover(args, select_all=False):
-    LOGGER.info('Starting discovery..')
+    LOGGER.info("Starting discovery..")
 
     catalog = {"streams": []}
     for stream in AVAILABLE_STREAMS:
@@ -39,10 +33,12 @@ def discover(args, select_all=False):
             "stream": stream.tap_stream_id,
             "tap_stream_id": stream.tap_stream_id,
             "schema": schema,
-            "metadata": singer.metadata.get_standard_metadata(schema=schema,
-                                                              key_properties=stream.key_properties,
-                                                              valid_replication_keys=stream.bookmark_properties,
-                                                              replication_method=stream.replication_method)
+            "metadata": singer.metadata.get_standard_metadata(
+                schema=schema,
+                key_properties=stream.key_properties,
+                valid_replication_keys=stream.bookmark_properties,
+                replication_method=stream.replication_method,
+            ),
         }
 
         if select_all is True:
@@ -50,11 +46,11 @@ def discover(args, select_all=False):
         catalog["streams"].append(catalog_entry)
 
     print(json.dumps(catalog, indent=2))
-    LOGGER.info('Finished discovery..')
+    LOGGER.info("Finished discovery..")
 
 
 def sync(args):
-    LOGGER.info('Starting sync..')
+    LOGGER.info("Starting sync..")
 
     selected_streams = {catalog_entry.stream for catalog_entry in args.catalog.get_selected_streams(args.state)}
     LOGGER.info(f"Selected Streams: {selected_streams}")
@@ -65,9 +61,11 @@ def sync(args):
             LOGGER.info(f"Starting sync for Stream {stream.tap_stream_id}..")
             singer.bookmarks.set_currently_syncing(state=stream.state, tap_stream_id=stream.tap_stream_id)
             singer.write_state(stream.state)
-            singer.write_schema(stream_name=stream.tap_stream_id,
-                                schema=stream.get_schema(tap_stream_id=stream.tap_stream_id, catalog=stream.catalog),
-                                key_properties=stream.key_properties)
+            singer.write_schema(
+                stream_name=stream.tap_stream_id,
+                schema=stream.get_schema(tap_stream_id=stream.tap_stream_id, catalog=stream.catalog),
+                key_properties=stream.key_properties,
+            )
             stream.sync()
             singer.bookmarks.set_currently_syncing(state=stream.state, tap_stream_id=None)
             singer.write_state(stream.state)
@@ -78,7 +76,7 @@ def _main():
     if args.discover:
         discover(args, select_all=args.select_all)
     elif not args.catalog:
-        raise RuntimeError('Catalog file must be supplied during Sync.')
+        raise RuntimeError("Catalog file must be supplied during Sync.")
     else:
         sync(args)
 

--- a/tap_dayforce/schemas/employees.json
+++ b/tap_dayforce/schemas/employees.json
@@ -1853,6 +1853,141 @@
     "SecondLastName": {
       "type": ["null", "string"]
     },
+    "Schedules": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "TimeStart": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "TimeEnd": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "NetHours": {
+            "type": ["null", "number"]
+          },
+          "DepartmentXRefCode": {
+            "type": ["null", "string"]
+          },
+          "JobXRefCode": {
+            "type": ["null", "string"]
+          },
+          "OrgUnitXRefCode": {
+            "type": ["null", "string"]
+          },
+          "OrgLocationTypeXRefCode": {
+            "type": ["null", "string"]
+          },
+          "PayAdjCodeXRefCode": {
+            "type": ["null", "string"]
+          },
+          "DocketXRefCode": {
+            "type": ["null", "string"]
+          },
+          "ProjectXRefCode": {
+            "type": ["null", "string"]
+          },
+          "Published": {
+            "type": ["null", "boolean"]
+          },
+          "Breaks": {
+            "type": ["null", "object"],
+            "properties": {
+              "Items": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "TimeStart": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "TimeEnd": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "NetHours": {
+                      "type": ["null", "number"]
+                    },
+                    "Type": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Activities": {
+            "type": ["null", "object"],
+            "properties": {
+              "Items": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "TimeStart": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "TimeEnd": {
+                      "type": ["null", "string"],
+                      "format": "date-time"
+                    },
+                    "XRefCode": {
+                      "type": ["null", "number"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Skills": {
+            "type": ["null", "object"],
+            "properties": {
+              "Items": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "SkillXRefCode": {
+                      "type": ["null", "string"]
+                    },
+                    "SkillLevelXRefCode": {
+                      "type": ["null", "string"]
+                    },
+                    "IsMandatory": {
+                      "type": ["null", "boolean"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "LaborMetrics": {
+            "type": ["null", "object"],
+            "properties": {
+              "Items": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "CodeXRefCode": {
+                      "type": ["null", "string"]
+                    },
+                    "TypeXRefCode": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "Suffix": {
       "type": ["null", "string"]
     },

--- a/tap_dayforce/schemas/employees.json
+++ b/tap_dayforce/schemas/employees.json
@@ -1894,93 +1894,73 @@
             "type": ["null", "boolean"]
           },
           "Breaks": {
-            "type": ["null", "object"],
-            "properties": {
-              "Items": {
-                "type": ["null", "array"],
-                "items": {
-                  "type": ["null", "object"],
-                  "properties": {
-                    "TimeStart": {
-                      "type": ["null", "string"],
-                      "format": "date-time"
-                    },
-                    "TimeEnd": {
-                      "type": ["null", "string"],
-                      "format": "date-time"
-                    },
-                    "NetHours": {
-                      "type": ["null", "number"]
-                    },
-                    "Type": {
-                      "type": ["null", "string"]
-                    }
-                  }
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "TimeStart": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "TimeEnd": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "NetHours": {
+                  "type": ["null", "number"]
+                },
+                "Type": {
+                  "type": ["null", "string"]
                 }
               }
             }
           },
           "Activities": {
-            "type": ["null", "object"],
-            "properties": {
-              "Items": {
-                "type": ["null", "array"],
-                "items": {
-                  "type": ["null", "object"],
-                  "properties": {
-                    "TimeStart": {
-                      "type": ["null", "string"],
-                      "format": "date-time"
-                    },
-                    "TimeEnd": {
-                      "type": ["null", "string"],
-                      "format": "date-time"
-                    },
-                    "XRefCode": {
-                      "type": ["null", "number"]
-                    }
-                  }
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "TimeStart": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "TimeEnd": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "XRefCode": {
+                  "type": ["null", "string"]
                 }
               }
             }
           },
           "Skills": {
-            "type": ["null", "object"],
-            "properties": {
-              "Items": {
-                "type": ["null", "array"],
-                "items": {
-                  "type": ["null", "object"],
-                  "properties": {
-                    "SkillXRefCode": {
-                      "type": ["null", "string"]
-                    },
-                    "SkillLevelXRefCode": {
-                      "type": ["null", "string"]
-                    },
-                    "IsMandatory": {
-                      "type": ["null", "boolean"]
-                    }
-                  }
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "SkillXRefCode": {
+                  "type": ["null", "string"]
+                },
+                "SkillLevelXRefCode": {
+                  "type": ["null", "string"]
+                },
+                "IsMandatory": {
+                  "type": ["null", "boolean"]
                 }
               }
             }
           },
           "LaborMetrics": {
-            "type": ["null", "object"],
-            "properties": {
-              "Items": {
-                "type": ["null", "array"],
-                "items": {
-                  "type": ["null", "object"],
-                  "properties": {
-                    "CodeXRefCode": {
-                      "type": ["null", "string"]
-                    },
-                    "TypeXRefCode": {
-                      "type": ["null", "string"]
-                    }
-                  }
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "CodeXRefCode": {
+                  "type": ["null", "string"]
+                },
+                "TypeXRefCode": {
+                  "type": ["null", "string"]
                 }
               }
             }

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -8,9 +8,8 @@ import requests
 import singer
 from dayforce_client import Dayforce
 
-from .utils import is_fatal_code, handle_rate_limit
-from .whitelisting import (WHITELISTED_COLLECTIONS, WHITELISTED_FIELDS,
-                           WHITELISTED_PAY_POLICY_CODES)
+from .utils import handle_rate_limit, is_fatal_code
+from .whitelisting import WHITELISTED_COLLECTIONS, WHITELISTED_FIELDS, WHITELISTED_PAY_POLICY_CODES
 
 LOGGER = singer.get_logger()
 
@@ -22,22 +21,28 @@ class DayforceStream(object):
     config: Dict = attr.ib(repr=False, validator=attr.validators.instance_of(Dict))
     config_path: Union[os.PathLike, str] = attr.ib()
     state: Dict = attr.ib(validator=attr.validators.instance_of(Dict))
-    catalog: Optional[singer.catalog.Catalog] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(singer.catalog.Catalog)),
-                                                        repr=False,
-                                                        default=None)
+    catalog: Optional[singer.catalog.Catalog] = attr.ib(
+        validator=attr.validators.optional(attr.validators.instance_of(singer.catalog.Catalog)),
+        repr=False,
+        default=None,
+    )
     catalog_path: Optional[Union[os.PathLike, str]] = attr.ib(default=None)
 
     @classmethod
     def from_args(cls, args, **kwargs):
-        return cls(client=Dayforce(username=args.config.get("username"),
-                                   password=args.config.get("password"),
-                                   client_namespace=args.config.get("client_namespace")),
-                   config=args.config,
-                   config_path=args.config_path,
-                   catalog=getattr(args, 'catalog', None),
-                   catalog_path=getattr(args, 'catalog_path', None),
-                   state=args.state,
-                   **kwargs)
+        return cls(
+            client=Dayforce(
+                username=args.config.get("username"),
+                password=args.config.get("password"),
+                client_namespace=args.config.get("client_namespace"),
+            ),
+            config=args.config,
+            config_path=args.config_path,
+            catalog=getattr(args, "catalog", None),
+            catalog_path=getattr(args, "catalog_path", None),
+            state=args.state,
+            **kwargs,
+        )
 
     @staticmethod
     def get_schema(tap_stream_id: str, catalog: singer.catalog.Catalog) -> Dict:
@@ -54,13 +59,19 @@ class DayforceStream(object):
 
 @attr.s
 class DayforcePunchStream(DayforceStream):
-
     def sync(self):
         with singer.metrics.job_timer(job_type=f"sync_{self.tap_stream_id}"):
             with singer.metrics.record_counter(endpoint=self.tap_stream_id) as counter:
-                start = singer.utils.strptime_to_utc(self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties))
+                start = singer.utils.strptime_to_utc(
+                    self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)
+                )
                 new_bookmark = singer.utils.now()
-                singer.bookmarks.write_bookmark(state=self.state, tap_stream_id=self.tap_stream_id, key=self.bookmark_properties, val=singer.utils.strftime(new_bookmark))
+                singer.bookmarks.write_bookmark(
+                    state=self.state,
+                    tap_stream_id=self.tap_stream_id,
+                    key=self.bookmark_properties,
+                    val=singer.utils.strftime(new_bookmark),
+                )
                 step = timedelta(days=6)
                 while start < new_bookmark:
                     end = start + step - timedelta(seconds=1)
@@ -70,90 +81,110 @@ class DayforcePunchStream(DayforceStream):
 
 @attr.s
 class EmployeePunchesStream(DayforcePunchStream):
-    tap_stream_id: ClassVar[str] = 'employee_punches'
-    key_properties: ClassVar[List[str]] = ['PunchXRefCode']
-    bookmark_properties: ClassVar[str] = 'SyncTimestampUtc'
-    replication_method: ClassVar[str] = 'INCREMENTAL'
+    tap_stream_id: ClassVar[str] = "employee_punches"
+    key_properties: ClassVar[List[str]] = ["PunchXRefCode"]
+    bookmark_properties: ClassVar[str] = "SyncTimestampUtc"
+    replication_method: ClassVar[str] = "INCREMENTAL"
 
-    @backoff.on_exception(backoff.expo,
-                          requests.exceptions.HTTPError,
-                          max_time=240,
-                          giveup=is_fatal_code,
-                          logger=LOGGER)
-    @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError,
-                           requests.exceptions.Timeout),
-                          max_time=240,
-                          logger=LOGGER)
+    @backoff.on_exception(
+        backoff.expo, requests.exceptions.HTTPError, max_time=240, giveup=is_fatal_code, logger=LOGGER
+    )
+    @backoff.on_exception(
+        backoff.expo, (requests.exceptions.ConnectionError, requests.exceptions.Timeout), max_time=240, logger=LOGGER
+    )
     def _transform_records(self, start, end, counter):
-        for _, record in self.client.get_employee_punches(filterTransactionStartTimeUTC=singer.utils.strftime(start), filterTransactionEndTimeUTC=singer.utils.strftime(end)).yield_records():
+        for _, record in self.client.get_employee_punches(
+            filterTransactionStartTimeUTC=singer.utils.strftime(start),
+            filterTransactionEndTimeUTC=singer.utils.strftime(end),
+        ).yield_records():
             if record:
-                record["SyncTimestampUtc"] = self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)
+                record["SyncTimestampUtc"] = self.get_bookmark(
+                    self.config, self.tap_stream_id, self.state, self.bookmark_properties
+                )
                 with singer.Transformer() as transformer:
-                    transformed_record = transformer.transform(data=record, schema=self.get_schema(self.tap_stream_id, self.catalog))
-                    singer.write_record(stream_name=self.tap_stream_id, time_extracted=singer.utils.now(), record=transformed_record)
+                    transformed_record = transformer.transform(
+                        data=record, schema=self.get_schema(self.tap_stream_id, self.catalog)
+                    )
+                    singer.write_record(
+                        stream_name=self.tap_stream_id, time_extracted=singer.utils.now(), record=transformed_record
+                    )
                     counter.increment()
 
 
 @attr.s
 class EmployeeRawPunchesStream(DayforcePunchStream):
-    tap_stream_id: ClassVar[str] = 'employee_raw_punches'
-    key_properties: ClassVar[List[str]] = ['RawPunchXRefCode']
-    bookmark_properties: ClassVar[str] = 'SyncTimestampUtc'
-    replication_method: ClassVar[str] = 'INCREMENTAL'
+    tap_stream_id: ClassVar[str] = "employee_raw_punches"
+    key_properties: ClassVar[List[str]] = ["RawPunchXRefCode"]
+    bookmark_properties: ClassVar[str] = "SyncTimestampUtc"
+    replication_method: ClassVar[str] = "INCREMENTAL"
 
-    @backoff.on_exception(backoff.expo,
-                          requests.exceptions.HTTPError,
-                          max_time=240,
-                          giveup=is_fatal_code,
-                          logger=LOGGER)
-    @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError,
-                           requests.exceptions.Timeout),
-                          max_time=240,
-                          logger=LOGGER)
+    @backoff.on_exception(
+        backoff.expo, requests.exceptions.HTTPError, max_time=240, giveup=is_fatal_code, logger=LOGGER
+    )
+    @backoff.on_exception(
+        backoff.expo, (requests.exceptions.ConnectionError, requests.exceptions.Timeout), max_time=240, logger=LOGGER
+    )
     def _transform_records(self, start, end, counter):
-        for _, record in self.client.get_employee_raw_punches(filterTransactionStartTimeUTC=singer.utils.strftime(start), filterTransactionEndTimeUTC=singer.utils.strftime(end)).yield_records():
+        for _, record in self.client.get_employee_raw_punches(
+            filterTransactionStartTimeUTC=singer.utils.strftime(start),
+            filterTransactionEndTimeUTC=singer.utils.strftime(end),
+        ).yield_records():
             if record:
-                record["SyncTimestampUtc"] = self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)
+                record["SyncTimestampUtc"] = self.get_bookmark(
+                    self.config, self.tap_stream_id, self.state, self.bookmark_properties
+                )
                 with singer.Transformer() as transformer:
-                    transformed_record = transformer.transform(data=record, schema=self.get_schema(self.tap_stream_id, self.catalog))
-                    singer.write_record(stream_name=self.tap_stream_id, time_extracted=singer.utils.now(), record=transformed_record)
+                    transformed_record = transformer.transform(
+                        data=record, schema=self.get_schema(self.tap_stream_id, self.catalog)
+                    )
+                    singer.write_record(
+                        stream_name=self.tap_stream_id, time_extracted=singer.utils.now(), record=transformed_record
+                    )
                     counter.increment()
 
 
 @attr.s
 class EmployeesStream(DayforceStream):
-    tap_stream_id: ClassVar[str] = 'employees'
-    key_properties: ClassVar[List[str]] = ['XRefCode']
-    bookmark_properties: ClassVar[str] = 'SyncTimestampUtc'
-    replication_method: ClassVar[str] = 'INCREMENTAL'
+    tap_stream_id: ClassVar[str] = "employees"
+    key_properties: ClassVar[List[str]] = ["XRefCode"]
+    bookmark_properties: ClassVar[str] = "SyncTimestampUtc"
+    replication_method: ClassVar[str] = "INCREMENTAL"
 
     def whitelist_sensitive_info(self, data: Dict) -> Dict:
         for collection in WHITELISTED_COLLECTIONS:
             if data.get(collection, {}).get("Items") is not None:
                 for i, item in enumerate(data.get(collection, {}).get("Items")):
-                    if item.get("PayPolicy") is None or item.get("PayPolicy").get("XRefCode") not in WHITELISTED_PAY_POLICY_CODES:
+                    if (
+                        item.get("PayPolicy") is None
+                        or item.get("PayPolicy").get("XRefCode") not in WHITELISTED_PAY_POLICY_CODES
+                    ):
                         for field in WHITELISTED_FIELDS:
                             data[collection]["Items"][i].pop(field, None)
 
         return data
 
-    @backoff.on_exception(backoff.expo,
-                          requests.exceptions.HTTPError,
-                          max_time=240,
-                          giveup=is_fatal_code,
-                          logger=LOGGER)
-    @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError,
-                           requests.exceptions.Timeout),
-                          max_time=240,
-                          logger=LOGGER)
+    @backoff.on_exception(
+        backoff.expo, requests.exceptions.HTTPError, max_time=240, giveup=is_fatal_code, logger=LOGGER
+    )
+    @backoff.on_exception(
+        backoff.expo, (requests.exceptions.ConnectionError, requests.exceptions.Timeout), max_time=240, logger=LOGGER
+    )
     def _transform_records(self, start, end, counter):
-        for _, record in self.client.get_employees(filterUpdatedStartDate=singer.utils.strftime(start), filterUpdatedEndDate=singer.utils.strftime(end)).yield_records():
+        for _, record in self.client.get_employees(
+            filterUpdatedStartDate=singer.utils.strftime(start), filterUpdatedEndDate=singer.utils.strftime(end)
+        ).yield_records():
             if record:
-                details = handle_rate_limit(func=self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers")).get("Data")
-                schedules = handle_rate_limit(func=self.client.get_employee_schedules(xrefcode=record.get("XRefCode"), expand="Activities,Breaks,Skills,LaborMetrics")).get("Data")
+                details = handle_rate_limit(
+                    func=self.client.get_employee_details(
+                        xrefcode=record.get("XRefCode"),
+                        expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers",
+                    )
+                ).get("Data")
+                schedules = handle_rate_limit(
+                    func=self.client.get_employee_schedules(
+                        xrefcode=record.get("XRefCode"), expand="Activities,Breaks,Skills,LaborMetrics"
+                    )
+                ).get("Data")
                 # try:
                 #     response = self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers")
                 # except requests.exceptions.HTTPError as e:
@@ -180,55 +211,71 @@ class EmployeesStream(DayforceStream):
                 # finally:
                 #     schedules = response.get("Data")
 
-
                 if details.get("XRefCode") is not None:
-                    details["SyncTimestampUtc"] = self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)
+                    details["SyncTimestampUtc"] = self.get_bookmark(
+                        self.config, self.tap_stream_id, self.state, self.bookmark_properties
+                    )
                     details = self.whitelist_sensitive_info(data=details)
                     details["Schedules"] = schedules
                     with singer.Transformer() as transformer:
-                        transformed_record = transformer.transform(data=details, schema=self.get_schema(self.tap_stream_id, self.catalog))
-                        singer.write_record(stream_name=self.tap_stream_id, time_extracted=singer.utils.now(), record=transformed_record)
+                        transformed_record = transformer.transform(
+                            data=details, schema=self.get_schema(self.tap_stream_id, self.catalog)
+                        )
+                        singer.write_record(
+                            stream_name=self.tap_stream_id, time_extracted=singer.utils.now(), record=transformed_record
+                        )
                         counter.increment()
 
     def sync(self):
         with singer.metrics.job_timer(job_type=f"sync_{self.tap_stream_id}"):
             with singer.metrics.record_counter(endpoint=self.tap_stream_id) as counter:
-                start = singer.utils.strptime_to_utc(self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties))
+                start = singer.utils.strptime_to_utc(
+                    self.get_bookmark(self.config, self.tap_stream_id, self.state, self.bookmark_properties)
+                )
                 new_bookmark = singer.utils.now()
-                singer.bookmarks.write_bookmark(state=self.state, tap_stream_id=self.tap_stream_id, key=self.bookmark_properties, val=singer.utils.strftime(new_bookmark))
+                singer.bookmarks.write_bookmark(
+                    state=self.state,
+                    tap_stream_id=self.tap_stream_id,
+                    key=self.bookmark_properties,
+                    val=singer.utils.strftime(new_bookmark),
+                )
                 self._transform_records(start, new_bookmark, counter)
 
 
 @attr.s
 class PaySummaryReportStream(DayforceStream):
-    tap_stream_id: ClassVar[str] = 'pay_summary_report'
+    tap_stream_id: ClassVar[str] = "pay_summary_report"
     key_properties: ClassVar[List[str]] = []
     bookmark_properties: ClassVar[List[str]] = []
-    replication_method: ClassVar[str] = 'FULL_TABLE'
-    date_param_fmt: ClassVar[str] = '%m/%d/%Y %I:%M:%S %p'
+    replication_method: ClassVar[str] = "FULL_TABLE"
+    date_param_fmt: ClassVar[str] = "%m/%d/%Y %I:%M:%S %p"
 
-    @backoff.on_exception(backoff.expo,
-                          requests.exceptions.HTTPError,
-                          max_time=240,
-                          giveup=is_fatal_code,
-                          logger=LOGGER)
-    @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError,
-                           requests.exceptions.Timeout),
-                          max_time=240,
-                          logger=LOGGER)
-    def _transform_records(self, start: datetime, end: datetime, counter: singer.metrics.Counter, time_extracted: datetime):
+    @backoff.on_exception(
+        backoff.expo, requests.exceptions.HTTPError, max_time=240, giveup=is_fatal_code, logger=LOGGER
+    )
+    @backoff.on_exception(
+        backoff.expo, (requests.exceptions.ConnectionError, requests.exceptions.Timeout), max_time=240, logger=LOGGER
+    )
+    def _transform_records(
+        self, start: datetime, end: datetime, counter: singer.metrics.Counter, time_extracted: datetime
+    ):
         report_params = {
             "003cd1ea-5f11-4fe8-ae9c-d7af1e3a95d6": singer.utils.strftime(start, format_str=self.date_param_fmt),
-            "b03cd1ea-5f11-4fe8-ae9c-d7af1e3a95d6": singer.utils.strftime(end, format_str=self.date_param_fmt)
+            "b03cd1ea-5f11-4fe8-ae9c-d7af1e3a95d6": singer.utils.strftime(end, format_str=self.date_param_fmt),
         }
         rows_returned = 0
-        for _, row in self.client.get_report(xrefcode="pay_summary_report", **report_params).yield_report_rows(limit=(500, 3600)):
+        for _, row in self.client.get_report(xrefcode="pay_summary_report", **report_params).yield_report_rows(
+            limit=(500, 3600)
+        ):
             if row:
                 rows_returned += 1
                 with singer.Transformer() as transformer:
-                    transformed_record = transformer.transform(data=row, schema=self.get_schema(self.tap_stream_id, self.catalog))
-                    singer.write_record(stream_name=self.tap_stream_id, record=transformed_record, time_extracted=time_extracted)
+                    transformed_record = transformer.transform(
+                        data=row, schema=self.get_schema(self.tap_stream_id, self.catalog)
+                    )
+                    singer.write_record(
+                        stream_name=self.tap_stream_id, record=transformed_record, time_extracted=time_extracted
+                    )
                     counter.increment()
 
         if 18000 <= rows_returned < 20000:

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -174,42 +174,21 @@ class EmployeesStream(DayforceStream):
             filterUpdatedStartDate=singer.utils.strftime(start), filterUpdatedEndDate=singer.utils.strftime(end)
         ).yield_records():
             if record:
+
                 details = handle_rate_limit(
                     func=self.client.get_employee_details(
                         xrefcode=record.get("XRefCode"),
                         expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers",
-                    )
+                    ),
+                    logger=LOGGER,
                 ).get("Data")
+
                 schedules = handle_rate_limit(
                     func=self.client.get_employee_schedules(
                         xrefcode=record.get("XRefCode"), expand="Activities,Breaks,Skills,LaborMetrics"
-                    )
+                    ),
+                    logger=LOGGER,
                 ).get("Data")
-                # try:
-                #     response = self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers")
-                # except requests.exceptions.HTTPError as e:
-                #     if e.response.status_code == 429:
-                #         sleep_time = int(e.response.headers["Retry-After"]) + 1
-                #         LOGGER.info(f"Rate limit reached. Retrying in {sleep_time} seconds..")
-                #         time.sleep(sleep_time)
-                #         response = self.client.get_employee_details(xrefcode=record.get("XRefCode"), expand="WorkAssignments,Contacts,EmploymentStatuses,Roles,EmployeeManagers,CompensationSummary,Locations,LastActiveManagers")
-                #     else:
-                #         raise
-                # finally:
-                #     details = response.get("Data")
-                #
-                # try:
-                #     response = self.client.get_employee_schedules(xrefcode=record.get("XRefCode"), expand="Activities,Breaks,Skills,LaborMetrics")
-                # except requests.exceptions.HTTPError as e:
-                #     if e.response.status_code == 429:
-                #         sleep_time = int(e.response.headers["Retry-After"]) + 1
-                #         LOGGER.info(f"Rate limit reached. Retrying in {sleep_time} seconds..")
-                #         time.sleep(sleep_time)
-                #         response = self.client.get_employee_schedules(xrefcode=record.get("XRefCode"), expand="Activities,Breaks,Skills,LaborMetrics")
-                #     else:
-                #         raise
-                # finally:
-                #     schedules = response.get("Data")
 
                 if details.get("XRefCode") is not None:
                     details["SyncTimestampUtc"] = self.get_bookmark(

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -188,7 +188,7 @@ class EmployeesStream(DayforceStream):
                         xrefcode=record.get("XRefCode"),
                         filterScheduleStartDate=singer.utils.strftime(start),
                         filterScheduleEndDate=singer.utils.strftime(end),
-                        expand="Activities,Breaks,Skills,LaborMetrics"
+                        expand="Activities,Breaks,Skills,LaborMetrics",
                     ),
                     logger=LOGGER,
                 ).get("Data")

--- a/tap_dayforce/streams.py
+++ b/tap_dayforce/streams.py
@@ -185,7 +185,10 @@ class EmployeesStream(DayforceStream):
 
                 schedules = handle_rate_limit(
                     func=self.client.get_employee_schedules(
-                        xrefcode=record.get("XRefCode"), expand="Activities,Breaks,Skills,LaborMetrics"
+                        xrefcode=record.get("XRefCode"),
+                        filterScheduleStartDate=singer.utils.strftime(start),
+                        filterScheduleEndDate=singer.utils.strftime(end),
+                        expand="Activities,Breaks,Skills,LaborMetrics"
                     ),
                     logger=LOGGER,
                 ).get("Data")
@@ -195,7 +198,8 @@ class EmployeesStream(DayforceStream):
                         self.config, self.tap_stream_id, self.state, self.bookmark_properties
                     )
                     details = self.whitelist_sensitive_info(data=details)
-                    details["Schedules"] = schedules
+                    if schedules is not None:
+                        details["Schedules"] = schedules
                     with singer.Transformer() as transformer:
                         transformed_record = transformer.transform(
                             data=details, schema=self.get_schema(self.tap_stream_id, self.catalog)

--- a/tap_dayforce/utils.py
+++ b/tap_dayforce/utils.py
@@ -4,24 +4,24 @@ import os
 import time
 from typing import Callable, Dict, Set
 
-from dayforce_client import DayforceResponse
 import requests
 import singer
+from dayforce_client import DayforceResponse
 
 
 def get_abs_path(path: str) -> str:
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
-def load_schema(tap_stream_id: str, schema_path: str = 'schemas') -> Dict:
+def load_schema(tap_stream_id: str, schema_path: str = "schemas") -> Dict:
     path = get_abs_path(schema_path)
     return singer.utils.load_json(f"{path}/{tap_stream_id}.json")
 
 
 def is_fatal_code(e: requests.exceptions.RequestException) -> bool:
-    '''Helper function to determine if a Requests reponse status code
+    """Helper function to determine if a Requests reponse status code
     is a "fatal" status code. If it is, the backoff decorator will giveup
-    instead of attemtping to backoff.'''
+    instead of attemtping to backoff."""
     return 400 <= e.response.status_code < 500 and e.response.status_code != 429
 
 
@@ -31,7 +31,7 @@ def load_json(path: str) -> Dict:
 
 
 def parse_args(required_config_keys: Set[str]) -> argparse.Namespace:
-    '''Parse standard command-line args.
+    """Parse standard command-line args.
     Parses the command-line arguments mentioned in the SPEC and the
     BEST_PRACTICES documents:
     -c,--config     Config file
@@ -43,43 +43,32 @@ def parse_args(required_config_keys: Set[str]) -> argparse.Namespace:
     Returns the parsed args object from argparse. For each argument that
     point to JSON files (config, state, properties), we will automatically
     load and parse the JSON file.
-    '''
+    """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument(
-        '-c', '--config',
-        help='Config file',
-        required=True)
+    parser.add_argument("-c", "--config", help="Config file", required=True)
+
+    parser.add_argument("-s", "--state", help="State file")
+
+    parser.add_argument("--catalog", help="Catalog file")
+
+    parser.add_argument("-d", "--discover", action="store_true", help="Do schema discovery")
 
     parser.add_argument(
-        '-s', '--state',
-        help='State file')
-
-    parser.add_argument(
-        '--catalog',
-        help='Catalog file')
-
-    parser.add_argument(
-        '-d', '--discover',
-        action='store_true',
-        help='Do schema discovery')
-
-    parser.add_argument(
-        '-a', '--select-all',
-        action='store_true',
-        help='Selects all streams in the Catalog for replication.')
+        "-a", "--select-all", action="store_true", help="Selects all streams in the Catalog for replication."
+    )
 
     args = parser.parse_args()
     if args.config:
-        setattr(args, 'config_path', args.config)
+        setattr(args, "config_path", args.config)
         args.config = load_json(args.config)
     if args.state:
-        setattr(args, 'state_path', args.state)
+        setattr(args, "state_path", args.state)
         args.state = load_json(args.state)
     else:
         args.state = {}
     if args.catalog:
-        setattr(args, 'catalog_path', args.catalog)
+        setattr(args, "catalog_path", args.catalog)
         args.catalog = singer.Catalog.load(args.catalog)
 
     check_config(args.config, required_config_keys)

--- a/tap_dayforce/whitelisting.py
+++ b/tap_dayforce/whitelisting.py
@@ -1,22 +1,14 @@
 from typing import Set
 
-WHITELISTED_COLLECTIONS: Set = {
-    'CompensationSummary',
-    'EmploymentStatuses'
-}
+WHITELISTED_COLLECTIONS: Set = {"CompensationSummary", "EmploymentStatuses"}
 
 WHITELISTED_FIELDS: Set = {
-    'BaseRate',
-    'BaseSalary',
-    'PreviousBaseRate',
-    'PreviousBaseSalary',
-    'ChangeValue',
-    'ChangePercent'
+    "BaseRate",
+    "BaseSalary",
+    "PreviousBaseRate",
+    "PreviousBaseSalary",
+    "ChangeValue",
+    "ChangePercent",
 }
 
-WHITELISTED_PAY_POLICY_CODES: Set = {
-    'USA_CA_HNE',
-    'USA_CA_HNE_4',
-    'USA_CA_HNEWHSE',
-    'USA_CA_HNEDRIVER'
-}
+WHITELISTED_PAY_POLICY_CODES: Set = {"USA_CA_HNE", "USA_CA_HNE_4", "USA_CA_HNEWHSE", "USA_CA_HNEDRIVER"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,58 +5,67 @@ import pytest
 from dayforce_client import Dayforce
 from singer.catalog import Catalog
 
-from tap_dayforce.streams import (EmployeePunchesStream,
-                                  EmployeeRawPunchesStream, EmployeesStream,
-                                  PaySummaryReportStream)
+from tap_dayforce.streams import (
+    EmployeePunchesStream,
+    EmployeeRawPunchesStream,
+    EmployeesStream,
+    PaySummaryReportStream,
+)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def config(shared_datadir):
-    with open(shared_datadir / 'test.config.json') as f:
+    with open(shared_datadir / "test.config.json") as f:
         return json.load(f)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def catalog(shared_datadir):
-    return Catalog.load(shared_datadir / 'test.catalog.json')
+    return Catalog.load(shared_datadir / "test.catalog.json")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def state(shared_datadir):
-    with open(shared_datadir / 'test.state.json') as f:
+    with open(shared_datadir / "test.state.json") as f:
         return json.load(f)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def employee_record(shared_datadir):
-    with open(shared_datadir / 'test.record.employee.json') as f:
+    with open(shared_datadir / "test.record.employee.json") as f:
         return json.load(f)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def dayforce_client(config):
-    return Dayforce(username=config.get("username"),
-                    password=config.get("password"),
-                    client_namespace=config.get("client_namespace"))
+    return Dayforce(
+        username=config.get("username"),
+        password=config.get("password"),
+        client_namespace=config.get("client_namespace"),
+    )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def args(dayforce_client, config, state, catalog, shared_datadir):
     args = argparse.Namespace()
-    setattr(args, 'client', dayforce_client)
-    setattr(args, 'config', config)
-    setattr(args, 'config_path', shared_datadir / 'test.config.json')
-    setattr(args, 'state', state)
-    setattr(args, 'catalog', catalog)
-    setattr(args, 'catalog_path', shared_datadir / 'test.catalog.json')
+    setattr(args, "client", dayforce_client)
+    setattr(args, "config", config)
+    setattr(args, "config_path", shared_datadir / "test.config.json")
+    setattr(args, "state", state)
+    setattr(args, "catalog", catalog)
+    setattr(args, "catalog_path", shared_datadir / "test.catalog.json")
     return args
 
 
-@pytest.fixture(scope='function', params={EmployeesStream, EmployeePunchesStream, EmployeeRawPunchesStream, PaySummaryReportStream})
+@pytest.fixture(
+    scope="function", params={EmployeesStream, EmployeePunchesStream, EmployeeRawPunchesStream, PaySummaryReportStream}
+)
 def stream(dayforce_client, config, state, shared_datadir, request):
-    return request.param(client=dayforce_client,
-                         config=config,
-                         config_path=shared_datadir / 'test.config.json',
-                         state=state,
-                         catalog=catalog,
-                         catalog_path=shared_datadir / 'test.catalog.json')
+    return request.param(
+        client=dayforce_client,
+        config=config,
+        config_path=shared_datadir / "test.config.json",
+        state=state,
+        catalog=catalog,
+        catalog_path=shared_datadir / "test.catalog.json",
+    )

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -2,41 +2,50 @@ import copy
 
 import pytest
 
-from tap_dayforce import (EmployeePunchesStream, EmployeeRawPunchesStream,
-                          EmployeesStream, PaySummaryReportStream)
-from tap_dayforce.whitelisting import (WHITELISTED_COLLECTIONS,
-                                       WHITELISTED_FIELDS)
+from tap_dayforce import EmployeePunchesStream, EmployeeRawPunchesStream, EmployeesStream, PaySummaryReportStream
+from tap_dayforce.whitelisting import WHITELISTED_COLLECTIONS, WHITELISTED_FIELDS
 
 
-@pytest.mark.parametrize('pt_stream', [EmployeesStream, EmployeeRawPunchesStream, EmployeePunchesStream, PaySummaryReportStream])
+@pytest.mark.parametrize(
+    "pt_stream", [EmployeesStream, EmployeeRawPunchesStream, EmployeePunchesStream, PaySummaryReportStream]
+)
 def test_stream_from_args_class_method(pt_stream, args, dayforce_client, config, state, catalog, shared_datadir):
     stream = pt_stream.from_args(args)
     assert stream.client == dayforce_client
     assert stream.config == config
-    assert stream.config_path == shared_datadir / 'test.config.json'
+    assert stream.config_path == shared_datadir / "test.config.json"
     assert stream.state == state
     assert stream.catalog == catalog
-    assert stream.catalog_path == shared_datadir / 'test.catalog.json'
+    assert stream.catalog_path == shared_datadir / "test.catalog.json"
 
 
-@pytest.mark.parametrize('pt_stream', [EmployeesStream, EmployeeRawPunchesStream, EmployeePunchesStream, PaySummaryReportStream])
+@pytest.mark.parametrize(
+    "pt_stream", [EmployeesStream, EmployeeRawPunchesStream, EmployeePunchesStream, PaySummaryReportStream]
+)
 def test_get_schema_static_method(pt_stream, catalog):
     schema = pt_stream.get_schema(tap_stream_id=pt_stream.tap_stream_id, catalog=catalog)
     assert isinstance(schema, dict)
 
 
-@pytest.mark.parametrize('pt_stream', [EmployeesStream, EmployeeRawPunchesStream, EmployeePunchesStream])
+@pytest.mark.parametrize("pt_stream", [EmployeesStream, EmployeeRawPunchesStream, EmployeePunchesStream])
 def test_get_bookmark_static_method(pt_stream, config, state):
     expected = state.get("bookmarks").get(pt_stream.tap_stream_id).get(pt_stream.bookmark_properties)
     bookmark = pt_stream.get_bookmark(config, pt_stream.tap_stream_id, state, pt_stream.bookmark_properties)
     assert expected == bookmark
 
 
-@pytest.mark.parametrize('pay_policy_xrefcode', ['SALARIED', 'CONTRACTOR', None,
-                                                 pytest.param('USA_CA_HNE', marks=pytest.mark.xfail),
-                                                 pytest.param('USA_CA_HNE_4', marks=pytest.mark.xfail),
-                                                 pytest.param('USA_CA_HNEWHSE', marks=pytest.mark.xfail),
-                                                 pytest.param('USA_CA_HNEDRIVER', marks=pytest.mark.xfail)])
+@pytest.mark.parametrize(
+    "pay_policy_xrefcode",
+    [
+        "SALARIED",
+        "CONTRACTOR",
+        None,
+        pytest.param("USA_CA_HNE", marks=pytest.mark.xfail),
+        pytest.param("USA_CA_HNE_4", marks=pytest.mark.xfail),
+        pytest.param("USA_CA_HNEWHSE", marks=pytest.mark.xfail),
+        pytest.param("USA_CA_HNEDRIVER", marks=pytest.mark.xfail),
+    ],
+)
 def test_employee_stream_whitelist(args, employee_record, pay_policy_xrefcode):
     stream = EmployeesStream.from_args(args)
     for collection in WHITELISTED_COLLECTIONS:

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,13 @@
 [tox]
 envlist = py38,py37,py36
 
-[flake8]
-ignore =
-  E501
-  E722
-count = True
-statistics = True
-
-[pytest]
-addopts = -v
-testpaths = tests
-
 [testenv]
 deps =
   -r dev-requirements.txt
 
 commands =
-  flake8 .
-  isort --recursive --check-only --diff
+  black . --check
+	flake8 . --count --statistics
+	isort --check-only --diff
   mypy .
   pytest


### PR DESCRIPTION
This PR adds data from the `employees/{XRefCode}/Schedules` endpoint to the existing Employees stream. This includes expanded data for Breaks, Activities, Skills, and LaborMetrics as well.

It also reformats the project to leverage Black code style.