### PR TITLE
Update version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0
+
+ - Added helper to handle 401 responses so entire call will not break.
+
+## 3.0.0
+
 ## 2.0.0
 
  - If an Item does not pass the whitelist, the entire Item will be omitted (where previously we only omitted certain fields).

--- a/tap_dayforce/utils.py
+++ b/tap_dayforce/utils.py
@@ -23,6 +23,8 @@ def is_fatal_code(e: requests.exceptions.RequestException) -> bool:
     """Helper function to determine if a Requests reponse status code
     is a "fatal" status code. If it is, the backoff decorator will giveup
     instead of attemtping to backoff."""
+    if e.response.status_code == 401:
+        return True
     return 400 <= e.response.status_code < 500 and e.response.status_code != 429
 
 
@@ -96,3 +98,19 @@ def handle_rate_limit(func: Callable, logger: logging.Logger) -> DayforceRespons
             raise
     finally:
         return response
+
+
+def handle_unauthorized(func: Callable, xrefcode: str, logger: logging.Logger) -> Dict:
+    """Handle unauthorized access to Dayforce API so not to break the tap.
+    401 Responses can occur for certain xrefcodes/employees which will return null.
+    """
+    try:
+        response = func()
+        return response.resp.json()
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code != 401:
+            logger.warn(f"HTTP error for XRefCode: {xrefcode}. Error: {e}")
+            raise
+        else:
+            logger.debug(f"Unauthorized access for XRefCode: {xrefcode}; returning null.")
+            return {"error": None}


### PR DESCRIPTION
Add handler for 401 responses.

Some emplyees may return 401 response and it is unclear why. Instead of having the entire employee stream break then helper will return `null`.